### PR TITLE
Add event for other mods to mark pickups as unshareable

### DIFF
--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -430,20 +430,13 @@ namespace ShareSuite
             return false;
         }
 
-        public class PickupValidityCheckEventData {
-            public bool pickupIsValid = true;
-            public readonly GenericPickupController pickup;
-
-            public PickupValidityCheckEventData(GenericPickupController pickup) {
-                this.pickup = pickup;
-            }
-        }
-        public static event EventHandler<PickupValidityCheckEventData> AdditionalPickupValidityChecks;
+        public static event Func<GenericPickupController, CharacterBody, bool> AdditionalPickupValidityChecks;
         public static bool IsValidPickupObject(GenericPickupController pickup, CharacterBody picker) {
             if(AdditionalPickupValidityChecks == null) return true;
-            var args = new PickupValidityCheckEventData(pickup);
-            AdditionalPickupValidityChecks.Invoke(picker, args);
-            return args.pickupIsValid;
+            var retv = true;
+            foreach(Func<GenericPickupController, CharacterBody, bool> f in AdditionalPickupValidityChecks.GetInvocationList())
+                retv &= f(pickup, picker);
+            return retv;
         }
         
         private static PickupIndex? GetRandomItemOfTier(ItemTier tier, PickupIndex orDefault)

--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -132,7 +132,7 @@ namespace ShareSuite
                 scrapperController.itemsEaten -= 1;
             }
         }
-
+        
         private static void OnGrantItem(On.RoR2.GenericPickupController.orig_AttemptGrant orig,
             GenericPickupController self, CharacterBody body)
         {
@@ -147,6 +147,7 @@ namespace ShareSuite
                     !Blacklist.HasItem(item.itemIndex))
                 && NetworkServer.active
                 && IsValidItemPickup(self.pickupIndex)
+                && IsValidPickupObject(self, body)
                 && GeneralHooks.IsMultiplayer())
             {
                 if (ShareSuite.RandomizeSharedPickups.Value)
@@ -429,6 +430,22 @@ namespace ShareSuite
             return false;
         }
 
+        public class PickupValidityCheckEventData {
+            public bool pickupIsValid = true;
+            public readonly GenericPickupController pickup;
+
+            public PickupValidityCheckEventData(GenericPickupController pickup) {
+                this.pickup = pickup;
+            }
+        }
+        public static event EventHandler<PickupValidityCheckEventData> AdditionalPickupValidityChecks;
+        public static bool IsValidPickupObject(GenericPickupController pickup, CharacterBody picker) {
+            if(AdditionalPickupValidityChecks == null) return true;
+            var args = new PickupValidityCheckEventData(pickup);
+            AdditionalPickupValidityChecks.Invoke(picker, args);
+            return args.pickupIsValid;
+        }
+        
         private static PickupIndex? GetRandomItemOfTier(ItemTier tier, PickupIndex orDefault)
         {
             switch (tier)

--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -132,7 +132,7 @@ namespace ShareSuite
                 scrapperController.itemsEaten -= 1;
             }
         }
-        
+
         private static void OnGrantItem(On.RoR2.GenericPickupController.orig_AttemptGrant orig,
             GenericPickupController self, CharacterBody body)
         {
@@ -431,8 +431,11 @@ namespace ShareSuite
         }
 
         public static event Func<GenericPickupController, CharacterBody, bool> AdditionalPickupValidityChecks;
-        public static bool IsValidPickupObject(GenericPickupController pickup, CharacterBody picker) {
-            if(AdditionalPickupValidityChecks == null) return true;
+
+        public static bool IsValidPickupObject(GenericPickupController pickup, CharacterBody picker)
+        {
+            if(AdditionalPickupValidityChecks == null)
+                return true;
             var retv = true;
             foreach(Func<GenericPickupController, CharacterBody, bool> f in AdditionalPickupValidityChecks.GetInvocationList())
                 retv &= f(pickup, picker);


### PR DESCRIPTION
### Purpose of change:

Allows any inventory drop mod, as well as any other similar case, to prevent a specific pickup object from being shared on pickup. External code can subscribe to the event, and return `true` if the pickup is OK to share or `false` otherwise. If any subscriber returns `false`, the pickup will be unshareable.

Necessary to address https://github.com/ThinkInvis/RoR2-Yeet/issues/15.

### Example implementation:

#### In TILER2:
```Csharp
public static class Compat_ShareSuite {
    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    public static void AddPickupEventHandler(Func<GenericPickupController, CharacterBody, bool> f) {
        ShareSuite.ItemSharingHooks.AdditionalPickupValidityChecks += f;
    }

    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    public static void RemovePickupEventHandler(Func<GenericPickupController, CharacterBody, bool> f) {
        ShareSuite.ItemSharingHooks.AdditionalPickupValidityChecks -= f;
    }

    private static bool? _enabled;
    public static bool enabled {
        get {
            if(_enabled == null) _enabled = BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey("com.funkfrog_sipondo.sharesuite");
            return (bool)_enabled;
        }
    }
}
```

#### In Yeet, during plugin Awake:
```Csharp
if(Compat_ShareSuite.enabled) {
    Compat_ShareSuite.AddPickupEventHandler((pickup, picker) => {
        return !pickup.TryGetComponent<YeetData>(out _); //component added to pickup objects created by dropping from player inventory
    });
}
```

### Notes:

A custom EventArgs class was not used because it would be difficult to handle as a soft dependency. It would make easily unsubscribing from the event impossible, as any reference to the subscribed function might include a missing type (the EventArgs class). This is what necessitated the manual multicast handling (iterating `event.GetInvocationList()`, instead of the usual single call to `event?.Invoke()`).