### PR TITLE
Bugfix/chat messages

### DIFF
--- a/ShareSuite/ChatHandler.cs
+++ b/ShareSuite/ChatHandler.cs
@@ -66,8 +66,9 @@ namespace ShareSuite
             if (!ShareSuite.RichMessagesEnabled.Value) orig(master, pickupIndex);
         }
 
-        public static void SendRichPickupMessage(CharacterMaster player, PickupDef pickupDef)
+        public static void SendRichPickupMessage(CharacterMaster player, GenericPickupController pickupController)
         {
+            PickupDef pickupDef = PickupCatalog.GetPickupDef(pickupController.pickupIndex);
             var body = player.hasBody ? player.GetBody() : null;
 
             if (!GeneralHooks.IsMultiplayer() || body == null || !ShareSuite.RichMessagesEnabled.Value)
@@ -94,7 +95,7 @@ namespace ShareSuite
                 return;
             }
 
-            if (Blacklist.HasItem(pickupDef.itemIndex) || !ItemSharingHooks.IsValidItemPickup(pickupDef.pickupIndex))
+            if (Blacklist.HasItem(pickupDef.itemIndex) || !ItemSharingHooks.IsValidItemPickup(pickupDef.pickupIndex) || !ItemSharingHooks.IsValidPickupObject(pickupController, body))
             {
                 var singlePickupMessage =
                     $"<color=#{playerColor}>{body.GetUserName()}</color> <color=#{GrayColor}>picked up</color> " +
@@ -139,9 +140,10 @@ namespace ShareSuite
             Chat.SendBroadcastChat(new Chat.SimpleChatMessage { baseToken = pickupMessage });
         }
 
-        public static void SendRichRandomizedPickupMessage(CharacterMaster origPlayer, PickupDef origPickup,
+        public static void SendRichRandomizedPickupMessage(CharacterMaster origPlayer, GenericPickupController origPickupController,
             Dictionary<CharacterMaster, PickupDef> pickupIndices)
         {
+            PickupDef origPickup = PickupCatalog.GetPickupDef(origPickupController.pickupIndex);
             if (!GeneralHooks.IsMultiplayer() || !ShareSuite.RichMessagesEnabled.Value)
             {
                 if (ShareSuite.RichMessagesEnabled.Value) SendPickupMessage(origPlayer, origPickup.pickupIndex);
@@ -152,7 +154,7 @@ namespace ShareSuite
             // If nobody got a randomized item
             if (pickupIndices.Count == 1)
             {
-                SendRichPickupMessage(origPlayer, origPickup);
+                SendRichPickupMessage(origPlayer, origPickupController);
                 return;
             }
 

--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -209,14 +209,14 @@ namespace ShareSuite
                 if (ShareSuite.RandomizeSharedPickups.Value)
                 {
                     orig(self, body);
-                    ChatHandler.SendRichRandomizedPickupMessage(master, item, randomizedPlayerDict);
+                    ChatHandler.SendRichRandomizedPickupMessage(master, self, randomizedPlayerDict);
                     return;
                 }
             }
 
             orig(self, body);
 
-            ChatHandler.SendRichPickupMessage(master, item);
+            ChatHandler.SendRichPickupMessage(master, self);
 
             // ReSharper disable once PossibleNullReferenceException
             HandleRichMessageUnlockAndNotification(master, item.pickupIndex);

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
@@ -16,7 +16,6 @@ namespace ShareSuite
 {
     [BepInDependency("com.bepis.r2api")]
     [BepInPlugin("com.funkfrog_sipondo.sharesuite", "ShareSuite", "2.8.0")]
-    [R2APISubmoduleDependency("CommandHelper")]
     [NetworkCompatibility(CompatibilityLevel.NoNeedForSync, VersionStrictness.DifferentModVersionsAreOk)]
     public class ShareSuite : BaseUnityPlugin
     {
@@ -84,7 +83,6 @@ namespace ShareSuite
         public ShareSuite()
         {
             InitConfig();
-            CommandHelper.AddToConsoleWhenReady();
 
             //On.RoR2.Networking.GameNetworkManager.OnClientConnect += (self, user, t) => { };
 


### PR DESCRIPTION
Fixes the misleading chat messages when other mods interact with ShareSuite (the chat messages say that the items are shared when in fact they are exempt from being shared).