### PR TITLE
Blacklist some SoTS DLC items

### DIFF
--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -350,7 +350,7 @@ namespace ShareSuite
             ItemBlacklist = Config.Bind(
                 "Settings",
                 "ItemBlacklist",
-                "BeetleGland,TreasureCache,TitanGoldDuringTP,TPHealingNova,ArtifactKey,FreeChest,RoboBallBuddy,MinorConstructOnKill",
+                "BeetleGland,TreasureCache,TitanGoldDuringTP,TPHealingNova,ArtifactKey,FreeChest,RoboBallBuddy,MinorConstructOnKill,LowerPricedChests,BarrageOnBoss,ItemDropChanceOnKill",
                 "Items (by internal name) that you do not want to share, comma separated. Please find the item \"Code Names\" at: https://github.com/risk-of-thunder/R2Wiki/wiki/Item-&-Equipment-IDs-and-Names"
             );
             ItemBlacklist.SettingChanged += (o, e) => Blacklist.Recalculate();


### PR DESCRIPTION
Items I'm proposing to ban sharing for:


| Item  | Internal Name | Rationale |
| ------------- | ------------- | ------------- |
| [Sale Star](https://riskofrain2.fandom.com/wiki/Sale_Star) | `LowerPricedChests` | "The item allows one to gain an extra item on the first chest opened per stage" If everyone in the party gets it, the party snowballs quickly |
| [Sonorous Whispers](https://riskofrain2.fandom.com/wiki/Sonorous_Whispers) | `ItemDropChanceOnKill` | "When a large monster is killed it will always drop an item." Same as Sale Star, snowballs really hard when the entire party has it
| [War Bonds](https://riskofrain2.fandom.com/wiki/War_Bonds)  | `BarrageOnBoss` | "During boss events, 5 missiles bombard the area". Pretty broken when everyone in the party has it (Mithrix dies in < 2 seconds). |

Let me know if you disagree with those, I'm happy to adjust.